### PR TITLE
upgrade to latest dependencies

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -88,6 +88,15 @@ jobs:
         kubectl -n vmware-sources describe pods
         kubectl -n vmware-sources get events
 
+    - name: Collect diagnostics
+      uses: chainguard-dev/actions/kind-diag@main
+      # Only upload logs on failure.
+      if: ${{ failure() }}
+      with:
+        cluster-resources: nodes
+        namespace-resources: pods,svc
+        artifact-name: logs
+
   plugins:
     name: kn plugins
     runs-on: ubuntu-latest


### PR DESCRIPTION
bumping k8s.io/kube-openapi e816edb...4241196:
  > 4241196 Merge pull request # 276 from Garima-Negi/fix-owners-file
  > a045323 Merge pull request # 272 from DangerOnTheRanger/openapi-v3-lazy-marshaling
  > 9765b7f Fix typo in OWNERS file
  > c1fc1de Merge pull request # 252 from austince/feat/decouple-restful
  > 8094b93 Add public documentation for HandlerCache.
  > 0d48a34 Merge pull request # 273 from hasheddan/fieldpath-rec
  > 0c8fa98 Testutil cleanup
  > 2dece3d Document that HandlerCache.New is not thread-safe.
  > 258b46d Remove unused code paths in object validator
  > 35b5ddc Add multiple status returns to int tests
  > 4e5b3ca Move HandlerCache to internal package & make HandlerCache tests external.
  > 16e8b81 Set path for schema validators embedded in schema props validators
  > 41ddd1e Take address of local loop var in route status code adapter
  > 9770bc8 Rename cache.go and cache_test.go.
  > 4c65bda Use JSONPath syntax for path indices
  > e9ebba8 Decouple integretion tests from GOPATH
  > 390a58b Remove toGzip from handler3/handler.go.
  > d5a90d6 Set path for all specific validators when set on SchemaValidator
  > eef04e7 Decouple REST Framework from v3
  > cb03b72 Add lazy marshaling for OpenAPIv3 handler.
  > c4d1aeb Decouple REST Framework
bumping gotest.tools/v3 568bc57...dc5149e:
  > dc5149e Merge pull request # 224 from DominicLavery/main
  > 7fe928e Merge pull request # 223 from seriousben/fix-golden-dir-creation
  > 7501e42 switch darwin defaults using runtime.GOOS
  > 10e310b Merge pull request # 222 from gotestyourself/fs-path-existing
  > b0ea9a7 Stop creating directory outside of testdata
  > aca5a3c Fix # 141 comparing symlink permissions
  > 196ee67 Merge pull request # 208 from dnephin/assert-error-is
  > cb4623d fs: add DirFromPath
  > 524f2ce Merge pull request # 221 from dnephin/go1.17
  > bc5434b Remove commented out line
  > 4fbf292 Merge pull request # 218 from thaJeztah/secure_exec
  > 4d8cea6 ci: add go1.17, remove go1.13
  > 567b2a0 lint: ignore line length in tests
  > fd36aec Merge pull request # 219 from dnephin/fix-windows-ci
  > 66ae1b5 icmd: replace all usages of os/exec with golang.org/x/sys/execabs
  > ae5beef assert: Add ErrorIs
  > c280cb4 Merge pull request # 217 from thaJeztah/bump_deps
  > 2dd0fa3 ci: set path for go install
  > cda9c22 go.mod: golang.org/x/tools v0.1.0
  > e419626 poll: small improvement to check functions
  > 3fcbc0e Merge pull request # 216 from thaJeztah/bump_go_16
  > 77bb3d3 go.mod: github.com/google/go-cmp v0.5.5
  > 1df0ee5 Merge pull request # 215 from dnephin/mkdir-in-update
  > d67588d CircleCI: update to GA version of Go 1.16
  > 059fb72 go.mod: github.com/pkg/errors v0.9.1
  > de21663 Merge pull request # 213 from dnephin/ci-go-1.16
  > fbb0800 golden: only create dir if update flag is set
  > 84d691d Merge pull request # 211 from dnephin/add-merge-main-workflow
  > eddfe6c ci: add go1.16
  > 4190a0e Add github action for merging main branch
bumping golang.org/x/time f0f3c7e...0e9765c:
  > 0e9765c rate: extend timing tolerances on Android and Plan9
  > 90d013b rate: allow for more timing slop in TestWaitSimple
bumping google.golang.org/genproto 9970aeb...1ac2ace:
  > 1ac2ace chore(all): auto-regenerate .pb.go files (# 768)
  > 15d65a4 chore(all): auto-regenerate .pb.go files (# 767)
  > 1da8797 chore(all): auto-regenerate .pb.go files (# 766)
  > 43724f9 chore(all): auto-regenerate .pb.go files (# 765)
  > daf9958 chore(all): auto-regenerate .pb.go files (# 764)
  > 94dd64e chore(all): auto-regenerate .pb.go files (# 763)
  > d576998 chore(all): auto-regenerate .pb.go files (# 762)
  > 4663080 chore(all): auto-regenerate .pb.go files (# 761)
  > e57b466 chore(all): auto-regenerate .pb.go files (# 760)
  > 1739428 chore(all): auto-regenerate .pb.go files (# 758)
  > 6fee9ac chore(all): auto-regenerate .pb.go files (# 757)
  > 65c12eb feat: bump grpc dep (# 756)
  > 7721543 chore: removate video/transcoder v1beta1 (# 755)
  > 5a51324 chore(all): auto-regenerate .pb.go files (# 754)
  > 0872dc9 chore(all): auto-regenerate .pb.go files (# 753)
  > d6cc3cc chore(all): auto-regenerate .pb.go files (# 752)
  > f4ae394 chore(all): auto-regenerate .pb.go files (# 751)
  > 2a053f0 chore(all): auto-regenerate .pb.go files (# 750)
  > 50beb8a chore(all): auto-regenerate .pb.go files (# 749)
bumping sigs.k8s.io/json c049b76...9f7c6b3:
  > 9f7c6b3 Merge pull request # 9 from liggitt/go117
  > 35920ff Merge pull request # 5 from liggitt/fullpath
  > e236582 Clarify go1.17 is required
  > be5ad23 Output field path in strict errors
bumping github.com/prometheus/procfs e971af5...f436cbb:
  > f436cbb Add NetStat to parse /proc/net/stat/... (# 316)
  > e979fa4 Fix data types for ignored stat fields # 401
  > f8ee60a fix zoneinfo name parsing (# 398)
  > 8506463 Fix cgroup path computation
  > 139df5d nvme: Wrap underlying errors instead of hiding them (# 397)
  > f73f4d0 Fix diskstats stats using sysfs (# 394)
  > cf1df72 Update common Prometheus files (# 395)
  > 8a561ca Update status badgets (# 388)
  > 6299d7d Initial fix for non-detection of OmniPath cards (# 387)
  > b62dc6f Add CmdLine function to parse /proc/cmdline (# 393)
  > 99f3c37 add additional stats from mdstat (# 380)
  > 70418d8 Merge pull request # 390 from prometheus/repo_sync
  > 1568b0e Merge pull request # 391 from wt-l00/fix-docs
  > 4464b7e Update common Prometheus files
  > 953e37b Add scsi_tape parser
  > f90a468 fix doc.go
  > 804a1a3 Merge pull request # 375 from binjip978/pid-stat
  > 8daa8ba Merge pull request # 373 from bi-zone/master
  > 6a1f500 Add RSSLimit, rt_priority, policy and delay_acct_block to pid/stat
  > afad6d6 Merge pull request # 369 from prometheus/superq/build_tag_check
  > fbd03f7 Add Inode filed into netIPSocketLine structe
  > 5162bec Merge pull request # 374 from treydock/ib-counters
  > f418198 Merge pull request # 366 from bdrung/nvme-infos
  > e1d8b42 Add check for sysfs build tag
  > 6df3a34 Use Linux only build tags in sysfs
  > b565fef Merge pull request # 365 from rfratto/class_thermal-exclude-freebsd
  > e291fd0 Add several Infiniband counters
  > cc9b84f Merge pull request # 370 from siavashs/drm
  > f514e44 Add support for NVMe
  > 2a76a6c Exclude freebsd from class_thermal
  > caa5b48 Merge pull request # 362 from prometheus/superq/parse_ib_rate
  > c111297 Merge pull request # 385 from prometheus/repo_sync
  > 1fccbdd Add tests for ClassDrmCardStats & update fixtures
  > c281efc Fix infiniband rate parsing
  > 6de0743 Merge pull request # 376 from digineo/netclass-by-iface
  > b6e8763 Update common Prometheus files
  > c53ce81 Parse /sys/class/drm/cardN/device/ stats
  > e8361a7 Merge pull request # 383 from prometheus/superq/fixture_repack
  > 8e91b32 Add NetClassByIface
  > 15245c5 Merge pull request # 371 from prometheus/repo_sync
  > 1369220 Repack fixtures.
  > 7f49865 Fix linter issue.
  > 6da175d Update build
  > 6ea6779 Update common Prometheus files
bumping knative.dev/networking 55757e9...1145ec5:
  > 1145ec5 upgrade to latest dependencies (# 658)
  > 56c4a3e upgrade to latest dependencies (# 657)
  > c173eed Add certificates config keys in config-network (# 648)
  > f96f8e2 upgrade to latest dependencies (# 655)
  > 224a816 Update actions (# 656)
  > 57ad9cf Update community files (# 654)
  > 88881dd Update community files (# 653)
  > 0d114b7 upgrade to latest dependencies (# 652)
  > 7307ffd Update community files (# 651)
  > 7fa8012 Update community files (# 650)
  > a49d1a2 Update actions (# 649)
  > 5dd0002 Update actions (# 647)
  > dde40b0 drop knative.dev/release label (# 646)
  > 0aef61e Update community files (# 645)
  > 84f7ed6 Update actions (# 644)
  > a1261cd Update community files (# 643)
  > 7e90d10 Update community files (# 642)
  > 09072d9 upgrade to latest dependencies (# 641)
bumping knative.dev/pkg 1f7514a...12be060:
  > 12be060 Update actions (# 2492)
  > e325df6 upgrade to latest dependencies (# 2490)
  > 00c122e Add genreconcile for ConfigMap (# 2489)
  > 6bb6518 Update actions (# 2488)
  > 5b0e728 drop deprecated eventing repos (# 2463)
  > 75629c8 Update community files (# 2487)
  > ca82d2b Add `NewProxyAutoTLSTransport` and `DialTLSWithBackOff` to support TLS proxy (# 2479)
  > e2b4d74 Update community files (# 2486)
  > 4d62e1d bump our min k8s version to 1.22 (# 2485)
  > 9ae44fe Update community files (# 2484)
  > 29f716f Fix `InitialBuckets()` for statefulSetBuilder's electors (# 2483)
  > 8db11d0 Update community files (# 2482)
  > dcd5d7c bump go version of tekton downstream workflow (# 2481)
  > 0ce1e92 Update actions (# 2480)
  > 4f42bf4 Update actions (# 2478)
  > 7479994 Update actions (# 2477)
  > c2f1f3e Update community files (# 2476)
  > 0a1ec2e upgrade to latest dependencies (# 2474)
bumping golang.org/x/oauth2 d3ed0bb...ee48083:
  > ee48083 go.mod: update vulnerable net library
bumping knative.dev/hack f067737...6ffd841:
  > 6ffd841 Update community files (# 168)
  > 02c525c Update community files (# 167)
  > 0e0784b Update community files (# 166)
  > a75ca49 Update community files (# 165)
  > 9c0ea69 Update community files (# 164)
  > c7a1ce1 Update community files (# 163)
bumping github.com/google/go-containerregistry 1571d7f...892d7a8:
  > 892d7a8 authn.kubernetes.Resolve now behaves exactly like Kubernetes (# 1349)
  > f1b7291 AuthConfig now supports json (un)marshalling (# 1350)
  > 7b4be6b fix(v1/remote): return an error if both auth and keychain are set (# 1334)
  > 610f826 fix(v1/random): set MediaType in randomIndex.manifest (# 1343)
  > f1b065c use k8s keychain first (# 1346)
  > 2042cc9 Bump codecov/codecov-action from 2.1.0 to 3.0.0 (# 1341)
  > a2b8a99 Bump actions/stale from 4 to 5 (# 1342)
  > 24b9440 Bump actions/setup-go from 2 to 3 (# 1340)
  > efc62d8 Bump peter-evans/create-pull-request from 3 to 4 (# 1327)
  > f1fa40b Add --user flag to crane mutate (# 1316)
  > d8a0048 Bump deps, fix ecr-login API change (# 1310)
  > 39e4996 Fix isolation of presubmit tools (# 1306)
  > 30512b8 Bump actions/checkout from 2 to 3 (# 1315)
  > 3295637 Don't parse challenge's scopes, put them first (# 1312)
  > bfe2ffc crane export: Support reading tarball from a stream (# 1274)
  > 5d4fcd4 Add rebase_test.sh to hack/presubmit.sh (# 1304)
  > 4029342 Bump golangci/golangci-lint-action from 2 to 3.1.0 (# 1308)
  > 445dc97 Include blob existence checks in retries (# 1307)
  > 86e1c81 Add GitHub Action to automatically bump deps (# 1291)
  > 17d8b10 Add output option to mutate to save to a tar file and not push to a registry (same as append) (# 1257)
  > dd8d514 Cover a couple special paths in keychain unit tests. (# 1302)
  > 0527e42 Take advantage of Chainguard maintained versions of various actions. (# 1301)
bumping google.golang.org/api c890ff5...aa4b661:
  > aa4b661 chore(main): release 0.70.0 (# 1446)
  > 459ebe0 feat(all): auto-regenerate discovery clients (# 1450)
  > 78984df chore(all): update all (# 1451)
  > 7bce545 feat(transport): add an env variable to disable DirectPath (# 1447)
  > 64db4b6 feat(all): auto-regenerate discovery clients (# 1449)
  > 0fe9f5f feat(all): auto-regenerate discovery clients (# 1448)
  > 7dec2b0 feat(all): auto-regenerate discovery clients (# 1444)
  > d8d1dd6 chore(main): release 0.69.0 (# 1429)
  > ed89fcb feat(all): auto-regenerate discovery clients (# 1443)
  > f47d942 chore(all): update all (# 1440)
  > 34437da feat(all): auto-regenerate discovery clients (# 1439)
  > ae341d5 feat(all): auto-regenerate discovery clients (# 1438)
  > c01dedc feat(all): auto-regenerate discovery clients (# 1437)
  > 50051fb chore: add PATH and HOME to cmds (# 1436)
  > 81492cc chore(internal/kokoro): add more debug info (# 1435)
  > 4499c41 fix(internal/kokoro): path to module root to run discogen (# 1433)
  > 14d6bf5 chore: add a script that invoke regen (# 1432)
  > ef89845 fix(gensupport): cover ChunkRetryDeadline edge case (# 1430)
  > 331bc9e feat: bump grpc and x/net (# 1428)
  > 79cd91d chore: remove synth.py (# 1427)
  > 31eaf11 chore(main): release 0.68.0 (# 1420)
  > f025530 fix: start reporting a meaningful version in headers (# 1426)
  > 5a35af5 feat(all): auto-regenerate discovery clients (# 1422)
  > 16cbba8 chore(all): update all (# 1423)
  > ca3165c chore(all): update all (major) (# 1412)
  > b28419f feat(all): auto-regenerate discovery clients (# 1419)
  > 9eaba81 fix(googleapi): fill response headers in Error (# 1418)
  > 6db1fa9 chore(main): release 0.67.0 (# 1413)
  > 6461d8f chore: run go mod tidy (# 1417)
  > f78a0f8 feat(all): auto-regenerate discovery clients (# 1416)
  > c987a5b feat(gensupport): per-chunk deadline configs (# 1414)
  > e40d61b feat(all): auto-regenerate discovery clients (# 1415)
  > a584462 feat(all): auto-regenerate discovery clients (# 1410)
  > 974d87e chore(all): update all (# 1411)
  > 51d1f3f chore: add new regen code (# 1403)
  > 5322ee8 chore(main): release 0.66.0 (# 1396)
  > 01c8604 feat(all): auto-regenerate discovery clients (# 1408)
  > 71e47d1 feat(all): auto-regenerate discovery clients (# 1407)
  > d972e9a feat(all): auto-regenerate discovery clients (# 1406)
  > 46a046b feat(all): auto-regenerate discovery clients (# 1405)
  > e4d33f2 feat(all): auto-regenerate discovery clients (# 1404)
  > 576ebbf feat(internal/gensupport): add 408 to default retry (# 1397)
  > 2f7c9e0 Adding import references in examples/customsearch (# 1399)
  > b6f8296 chore(all): update all (# 1400)
  > f3223f8 Switch drive.go to v3 API (# 1334)
  > 33250c0 feat(all): auto-regenerate discovery clients (# 1394)
bumping knative.dev/eventing 3890b39...3e24a78:
  > 3e24a78 NPE fix (# 6343)
  > 1104746 [scheduler] Use node taints for keeping track of available nodes and zones (# 6291)
  > 39eef14 upgrade to latest dependencies (# 6341)
  > 073af74 Ensure the clean up will remove installed elements (# 6338)
  > ff55a45 Fix for pod overcommit by one in HA Scheduler (# 6322)
  > 5bb50cb Allow adapter/v2 based components to use ConfigMapWatcher (# 6086)
  > d14dc09 upgrade to latest dependencies (# 6327)
  > 6d61534 Update actions (# 6328)
  > 76ce7e4 Cleanup Zipkin tracing only once in upgrade test suite (# 6331)
  > 1b90ef3 Limit the number of exported traces (# 6329)
  > 2222324 Update actions (# 6323)
  > e7459cb upgrade to latest dependencies (# 6324)
  > e874b89 upgrade to latest dependencies (# 6321)
  > fd10179 Update community files (# 6320)
  > bb76b30 Update community files (# 6310)
  > 5accb7a Update actions (# 6303)
  > 2ff606c upgrade to latest dependencies (# 6307)
  > 58865af Update community files (# 6305)
  > c6fd9d4 Update community files (# 6304)
  > dcdd9e0 [rekt] Improve various isReady/GoesReady checks (# 6241)
  > 05733bf 💄 symlink the observability file (# 6301)
  > d1bb7a8 Update actions (# 6300)
  > 632efa5 Do not fail upgrade tests if tracing is not configured (# 6299)
  > aaa15c1 Symlink tracing.yaml config map (# 6295)
  > 741fb0e Update community files (# 6296)
  > 06f57ca Add sugar namespace and trigger reconcilers to main eventing controller (# 6027)
  > 380849f Print traces for missed events in upgrade tests (# 6249)
  > 38562c3 Update actions (# 6294)
  > 5ede92d Update community files (# 6293)
  > 02663e2 Update community files (# 6290)
  > 04eafff Process empty tracing config in test images (# 6289)
bumping knative.dev/client 1bab820...ff097e9:
  > ff097e9 upgrade to latest dependencies (# 1659)
  > d8ab3d5 upgrade to latest dependencies (# 1658)
  > 9154f26 Fix build warning from go version upgrade (# 1657)
  > b858dab Added subpath functionality to --mount flag (# 1655)
  > 7e8a672 upgrade to latest dependencies (# 1656)
  > bb055ee Added scale-metric flag to configure metric name (# 1653)
  > 76f17f6 Upgrade Go to 1.17 (# 1654)
  > 1cb29fb upgrade to latest dependencies (# 1652)
  > 2929f38 Added flag to configure wait-window between intermediate errors durin… (# 1645)
  > 0ac405d Add timeout option to service create (# 1643)
  > bb7fd73 Added pull-policy flag to service (# 1644)
  > 0d4e83b Update actions (# 1651)
  > b4e95db upgrade to latest dependencies (# 1650)
  > 0993e23 Align codecov config with rest of the org (# 1649)
  > e3d4191 Update actions (# 1648)
  > d07b600 upgrade to latest dependencies (# 1642)
  > b702b42 Fix latest release CI setup (# 1647)
  > 5daa09d Update community files (# 1646)
  > 26ba0e2 Update community files (# 1641)
  > e074fff Update actions (# 1639)
  > f8129fe upgrade to latest dependencies (# 1638)
  > 6170c6d Update community files (# 1640)
  > 73b2d8b Update actions (# 1637)
  > 38b1034 Update community files (# 1636)

Signed-off-by: Knative Automation <automation@knative.team>